### PR TITLE
fix: add catkin build command to our dev image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ FROM osrf/ros:noetic-desktop-full-focal
 RUN apt update && apt install -y vim tmux x11-apps mesa-utils python3-pip htop
 
 # Settings ROS development environment
-RUN apt update && DEBIAN_FRONTEND=noninteractive apt install -y ros-noetic-rtabmap-ros ros-noetic-robot-localization liburdfdom-tools
+RUN apt update && DEBIAN_FRONTEND=noninteractive apt install -y ros-noetic-rtabmap-ros ros-noetic-robot-localization liburdfdom-tools python3-catkin-tools
 
 # Configure the environment.
 RUN echo "set -g mouse on" >> /root/.tmux.conf


### PR DESCRIPTION
- With this PR we're able to compile our codebase accordingly with the [auv_gnc](https://github.com/ufrj-nautilus/auv_gnc) requirements
- Closes #17 